### PR TITLE
fix symbolic link not updated from previously botched installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In Plasma versions < 5.24, a bug in the KWin scripting system [[1]](https://bugs
 ```bash
 sed -i 's/ConfigModule/Library/g' ~/.local/share/kwin/scripts/tilegaps/metadata.desktop
 mkdir -p ~/.local/share/kservices5/
-ln -s ~/.local/share/kwin/scripts/tilegaps/metadata.desktop ~/.local/share/kservices5/tilegaps.desktop
+ln -sf ~/.local/share/kwin/scripts/tilegaps/metadata.desktop ~/.local/share/kservices5/tilegaps.desktop
 qdbus org.kde.KWin /KWin reconfigure
 ```
 


### PR DESCRIPTION
without the `-f` to force the following error occurred and the config dialog will not open
```
ln -s ~/.local/share/kwin/scripts/tilegaps/metadata.desktop ~/.local/share/kservices5/tilegaps.desktop
ln: failed to create symbolic link '/home/<redacted>/.local/share/kservices5/tilegaps.desktop': File exists
```